### PR TITLE
Fix ability to run in a nested directory under repository

### DIFF
--- a/lib/git_evolution.rb
+++ b/lib/git_evolution.rb
@@ -4,7 +4,7 @@ module GitEvolution
   def self.run(args)
     options = OptionHandler.parse_options(args)
 
-    repo = Repository.new(File.dirname(File.expand_path(options.file)))
+    repo = Repository.new(options.file)
     commits = repo.line_commits(options.start_line, options.end_line, options.file, options.since)
 
     ReportPresenter.new(commits).print

--- a/lib/git_evolution/option_handler.rb
+++ b/lib/git_evolution/option_handler.rb
@@ -19,7 +19,7 @@ module GitEvolution
         end
       end.parse!
 
-      options[:file] = args[0]
+      options[:file] = File.expand_path(args[0])
       options[:start_line], options[:end_line] = parse_range(options[:range])
 
       validate_options!(options)


### PR DESCRIPTION
The git commands needs the absolute file path, or relative 'from' the root of the repo's directory. This fix makes the file an absolute path'd file while parsing it in the OptionHandler.