### PR TITLE
fix: The line range (-L) doesn't work with the follow option

### DIFF
--- a/lib/git_evolution/repository.rb
+++ b/lib/git_evolution/repository.rb
@@ -15,12 +15,13 @@ module GitEvolution
 
     def raw_line_history(start_line, end_line, file, since = nil)
       since_option = "--since '#{since}'"
+      range_option = "-L#{start_line},#{end_line}:#{file}"
+      follow_option = "--follow '#{file}'"
 
       Dir.chdir(dir) do
         return `git --no-pager log -p -z\
-        #{since_option if since}\
-        #{"-L#{start_line},#{end_line}:#{file}" if start_line && end_line}\
-        --follow #{file}`
+         #{since_option if since}\
+         #{start_line && end_line ? range_option : follow_option}`
       end
     end
   end


### PR DESCRIPTION
As introduce in https://github.com/git/git/commit/39664cb0aca42f240468ddf84fe75df4172ab63f the `-L` and `--follow` options don't work together. This commit addresses this by only use one or the other based on the presence of the start/end line options being passed in.

This fixes up the `fatal: -L<range>:<file> cannot be used with pathspec` error, as well as broken specs.