### PR TITLE
chore: update the gem dependencies to be more future thinking

### DIFF
--- a/git_evolution.gemspec
+++ b/git_evolution.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['kevin.j.jalbert@gmail.com']
   spec.summary       = 'Gem that provides the ability to determine the evolution of code within a git repository'
   spec.description   = 'Gem that provides the ability to determine the evolution of code within a git repository'
-  spec.homepage      = ''
+  spec.homepage      = 'https://github.com/kevinjalbert/git_evolution'
   spec.license       = 'MIT'
 
   spec.files         = Dir['**/*']
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir['bin/*'].map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler', '~> 2.0'
-  spec.add_dependency 'rake', '~> 10.0'
-  spec.add_dependency 'rugged', '~> 0.21.0'
-  spec.add_dependency 'chronic', '~> 0.10.0'
+  spec.add_dependency 'bundler', '>= 2.0'
+  spec.add_dependency 'rake', '>= 13.0'
+  spec.add_dependency 'rugged', '>= 0.21.0'
+  spec.add_dependency 'chronic', '>= 0.10.0'
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '>= 2.5'
 end


### PR DESCRIPTION
This change makes it so the gem dependencies are more future thinking
and can upgrade past the pessimistic version constraints.

This addresses a security concern with rake as well (fixed in 12.3.3).

The homepage was changed to specify the github repos page